### PR TITLE
Changing the API endpoint url

### DIFF
--- a/src/CarsList.js
+++ b/src/CarsList.js
@@ -38,7 +38,7 @@ export class CarsList extends React.Component {
             method: 'POST',
             body: this.state.ID
         };
-        fetch('http://3.138.195.107/cars',requestOptions)
+        fetch('https://cb.caravantage.tech/cars',requestOptions)
             // Handle success
             .then(response => response.json())  // convert to json
             .then(


### PR DESCRIPTION
Changed our API endpoint URL from the HTTP IP address to the public HTTPS domain.

<!--- Summarize your change in the title -->
<!--- Unless you are ready to merge it in, make this a draft. -->

## Context

<!--- Why did we make this change? What is the current implementation? -->
Our current code contained the EC2's public IP address harcoded as the API endpoint URL and it was using the HTTP protocol instead of HTTPS. 
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

**Description**:
<!--- Describe your changes here, in enough detail that anyone can understand what you did -->

In the one line for making a POST request, I have changed the URL from the IP address to the public domain having installed the ssl certification to the EC2 and getting our domain registered.

**Type of change** (select all that apply):

<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. -->

- [x] Breaking change (changing code functionality)

## Testing

<!--- Please describe in detail how you tested this pull request, even if its just how to run it. -->
Doing curl requests and checking from the browser locally showed that the API connection was working to the specified domain, and rerunning the code as before also shows no issues at the moment.

## Checklist

- [x] Code is up to date with main branch (no merge conflicts)
- [x] Code has been properly tested
- [x] Code has been properly documented
- [ ] One or two people have reviewed this pull request <!-- check this after making the PR -->
